### PR TITLE
Fix: Multi-GPU usage with Virtual Display

### DIFF
--- a/display/manager.py
+++ b/display/manager.py
@@ -2993,6 +2993,8 @@ user_value="${{USER:-$(id -un)}}"
 logname_value="${{LOGNAME:-$user_value}}"
 shell_value="${{SHELL:-/bin/sh}}"
 dbus_value="${{DBUS_SESSION_BUS_ADDRESS:-unix:path=$runtime_dir/bus}}"
+wlr_drm_devices_value="/dev/dri/by-path/card1"
+wlr_render_drm_device_value="/dev/dri/renderD128"
 
 cleanup() {{
     rm -f "$before_file" "$after_file"
@@ -3028,6 +3030,8 @@ unset KDE_SESSION_VERSION
     SWAYSOCK="{state['sway_socket']}" \
     WLR_BACKENDS=headless,libinput \
     LIBSEAT_BACKEND=noop \
+    WLR_DRM_DEVICES="$wlr_drm_devices_value" \
+    WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value" \
     /usr/bin/sway --config "{paths['sway_config']}" &
 sway_pid=$!
 
@@ -3591,6 +3595,10 @@ PY
 run_headless_command() {{
     local command_to_run="$1"
     log_debug "running prep command: $command_to_run"
+    
+    wlr_drm_devices_value="/dev/dri/by-path/card1"
+    wlr_render_drm_device_value="/dev/dri/renderD128"
+    
     local -a launch_command
     launch_command=(/usr/bin/env -i
         "HOME=$home_value"
@@ -3612,6 +3620,8 @@ run_headless_command() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
+        "WLR_DRM_DEVICES="$wlr_drm_devices_value"
+        "WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value"
     )
     launch_command+=(/bin/sh -lc "$command_to_run")
     "${{launch_command[@]}}" >>"$launch_log_file" 2>&1
@@ -3929,6 +3939,10 @@ launch_headless_direct() {{
     local command_to_run="$1"
 {mangohud_fps_limit_block.rstrip()}
     log_debug "launch command: $command_to_run"
+
+    wlr_drm_devices_value="/dev/dri/by-path/card1"
+    wlr_render_drm_device_value="/dev/dri/renderD128"
+
     local -a launch_command
     launch_command=(/usr/bin/env -i
         "HOME=$home_value"
@@ -3951,6 +3965,8 @@ launch_headless_direct() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
+        "WLR_DRM_DEVICES="$wlr_drm_devices_value"
+        "WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value"
     )
 {mangohud_env_append_block.rstrip()}
     launch_command+=(/bin/sh -lc "$command_to_run")

--- a/display/manager.py
+++ b/display/manager.py
@@ -2996,11 +2996,16 @@ shell_value="${{SHELL:-/bin/sh}}"
 dbus_value="${{DBUS_SESSION_BUS_ADDRESS:-unix:path=$runtime_dir/bus}}"
 
 gpu_addr=$({paths['get_gpu_addr']})
-if [ -z "$gpu_addr" ]; then
-    // TODO: Create script for internal GPU if no dedicated CPU was found
+IFS='-' read -a gpu_array <<< "$gpu_addr"
+
+if [[ -n ${{gpu_array[0]}} ]]; then
+    external_gpu=${{gpu_array[0]}}
+    wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
+    wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
 else
-    wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
-    wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+    internal_gpu=${{gpu_array[1]}}
+    wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
+    wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
 fi
 
 cleanup() {{
@@ -3604,11 +3609,16 @@ run_headless_command() {{
     log_debug "running prep command: $command_to_run"
     
     gpu_addr=$({paths['get_gpu_addr']})
-    if [ -z "$gpu_addr" ]; then
-        // TODO: Create script for internal GPU if no dedicated CPU was found
+    IFS='-' read -a gpu_array <<< "$gpu_addr"
+
+    if [[ -n ${{gpu_array[0]}} ]]; then
+        external_gpu=${{gpu_array[0]}}
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
     else
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+        internal_gpu=${{gpu_array[1]}}
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
     fi
     
     local -a launch_command
@@ -3953,11 +3963,16 @@ launch_headless_direct() {{
     log_debug "launch command: $command_to_run"
 
     gpu_addr=$({paths['get_gpu_addr']})
-    if [ -z "$gpu_addr" ]; then
-        // TODO: Create script for internal GPU if no dedicated CPU was found
+    IFS='-' read -a gpu_array <<< "$gpu_addr"
+
+    if [[ -n ${{gpu_array[0]}} ]]; then
+        external_gpu=${{gpu_array[0]}}
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
     else
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+        internal_gpu=${{gpu_array[1]}}
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
     fi
 
     local -a launch_command
@@ -4460,6 +4475,7 @@ exit "$child_status"
 """,
         Path(paths["get_gpu_addr"]): f"""#!/bin/bash
 discrete_gpu=""
+internal_gpu=""
 for gpu in /sys/class/drm/card[0-9]; do
     # if no directory found continue
     [ -e "$gpu" ] || continue
@@ -4473,9 +4489,10 @@ for gpu in /sys/class/drm/card[0-9]; do
 
     # Logic for Intel (Vendor 0x8086)
     if [[ "$vendor_id" == "0x8086" ]]; then
-        # Check auf die typische integrierte Adresse 0000:00:02.0
+        # Check for typical integrated adrress
         if [[ "$pci_addr" == "0000:00:02.0" ]]; then
             type="Integrated"
+            internal_gpu=$pci_addr
         else
             type="Discrete"
             discrete_gpu=$pci_addr
@@ -4483,9 +4500,10 @@ for gpu in /sys/class/drm/card[0-9]; do
 
     # Logic for AMD (Vendor 0x1002)
     elif [[ "$vendor_id" == "0x1002" ]]; then
-        # Suche nach der Northbridge-Spannungsdatei im hwmon-Ordner
+        # Search on Northbridge in hwmon folder
         if ls "$gpu/device/hwmon"/hwmon*/in1_input >/dev/null 2>&1; then
             type="Integrated"
+            internal_gpu=$pci_addr
         else
             type="Discrete"
             discrete_gpu=$pci_addr
@@ -4493,13 +4511,13 @@ for gpu in /sys/class/drm/card[0-9]; do
 
     # Logic for NVIDIA (Vendor 0x10de)
     elif [[ "$vendor_id" == "0x10de" ]]; then
-        # NVIDIA ist fast immer Discrete (außer bei sehr alten Tegra-Chips)
+        # NVIDIA ist almost always descrete (except for old Tegra-Chips)
         type="Discrete"
         discrete_gpu=$pci_addr
     fi
 done
 
-echo $discrete_gpu
+echo $discrete_gpu-$internal_gpu
         """,
         Path(paths["resolve_stream_fps_script"]): f"""#!/bin/bash
 set -euo pipefail

--- a/display/manager.py
+++ b/display/manager.py
@@ -3642,8 +3642,8 @@ run_headless_command() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
-        "WLR_DRM_DEVICES="$wlr_drm_devices_value"
-        "WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value"
+        "WLR_DRM_DEVICES=$wlr_drm_devices_value"
+        "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
     )
     launch_command+=(/bin/sh -lc "$command_to_run")
     "${{launch_command[@]}}" >>"$launch_log_file" 2>&1
@@ -3997,8 +3997,8 @@ launch_headless_direct() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
-        "WLR_DRM_DEVICES="$wlr_drm_devices_value"
-        "WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value"
+        "WLR_DRM_DEVICES=$wlr_drm_devices_value"
+        "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
     )
 {mangohud_env_append_block.rstrip()}
     launch_command+=(/bin/sh -lc "$command_to_run")

--- a/display/manager.py
+++ b/display/manager.py
@@ -609,6 +609,7 @@ def _state_paths() -> Dict[str, str]:
         "headless_prep_script": str(BIN_ROOT / "lutristosunshine-run-headless-prep.sh"),
         "set_resolution_script": str(BIN_ROOT / "lutristosunshine-set-resolution.sh"),
         "reset_resolution_script": str(BIN_ROOT / "lutristosunshine-reset-resolution.sh"),
+        "get_gpu_addr": str(BIN_ROOT / "lutristosunshine-get-gpu-addr.sh"),
         "portal_lock_file": str(PORTAL_LOCK_PATH),
         "portal_active_file": str(PORTAL_ACTIVE_PATH),
         "last_launch_log_file": str(LAST_LAUNCH_LOG_PATH),
@@ -2982,6 +2983,8 @@ input "48879:57005:Mouse_passthrough_(absolute)" accel_profile flat
         Path(paths["sway_start_script"]): f"""#!/bin/bash
 set -euo pipefail
 
+gpu_addr=$({paths['get_gpu_addr']})
+
 runtime_dir="${{XDG_RUNTIME_DIR:-/run/user/$(id -u)}}"
 display_file="{paths['wayland_display_file']}"
 before_file="$(mktemp)"
@@ -2993,8 +2996,13 @@ user_value="${{USER:-$(id -un)}}"
 logname_value="${{LOGNAME:-$user_value}}"
 shell_value="${{SHELL:-/bin/sh}}"
 dbus_value="${{DBUS_SESSION_BUS_ADDRESS:-unix:path=$runtime_dir/bus}}"
-wlr_drm_devices_value="/dev/dri/by-path/card1"
-wlr_render_drm_device_value="/dev/dri/renderD128"
+
+if [ -z "$gpu_addr" ]; then
+    // TODO: Create script for internal GPU if no dedicated CPU was found
+else
+    wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
+    wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+fi
 
 cleanup() {{
     rm -f "$before_file" "$after_file"
@@ -4441,6 +4449,49 @@ rm -f "$host_env_file" "$systemd_env_dump"
 log_debug "wrapper final exit status=$child_status"
 exit "$child_status"
 """,
+        Path(paths["get_gpu_addr"]): f"""#!/bin/bash
+discrete_gpu=""
+for gpu in /sys/class/drm/card[0-9]; do
+    # if no directory found continue
+    [ -e "$gpu" ] || continue
+
+    # get pci-id of card
+    pci_addr=$(basename $(readlink -f "$gpu/device"))
+    vendor_id=$(cat "$gpu/device/vendor")
+    device_id=$(cat "$gpu/device/device")
+    
+    type="Unknown"
+
+    # Logic for Intel (Vendor 0x8086)
+    if [[ "$vendor_id" == "0x8086" ]]; then
+        # Check auf die typische integrierte Adresse 0000:00:02.0
+        if [[ "$pci_addr" == "0000:00:02.0" ]]; then
+            type="Integrated"
+        else
+            type="Discrete"
+            discrete_gpu=$pci_addr
+        fi
+
+    # Logic for AMD (Vendor 0x1002)
+    elif [[ "$vendor_id" == "0x1002" ]]; then
+        # Suche nach der Northbridge-Spannungsdatei im hwmon-Ordner
+        if ls "$gpu/device/hwmon"/hwmon*/in1_input >/dev/null 2>&1; then
+            type="Integrated"
+        else
+            type="Discrete"
+            discrete_gpu=$pci_addr
+        fi
+
+    # Logic for NVIDIA (Vendor 0x10de)
+    elif [[ "$vendor_id" == "0x10de" ]]; then
+        # NVIDIA ist fast immer Discrete (außer bei sehr alten Tegra-Chips)
+        type="Discrete"
+        discrete_gpu=$pci_addr
+    fi
+done
+
+echo $discrete_gpu
+        """,
         Path(paths["resolve_stream_fps_script"]): f"""#!/bin/bash
 set -euo pipefail
 

--- a/display/manager.py
+++ b/display/manager.py
@@ -2983,8 +2983,6 @@ input "48879:57005:Mouse_passthrough_(absolute)" accel_profile flat
         Path(paths["sway_start_script"]): f"""#!/bin/bash
 set -euo pipefail
 
-gpu_addr=$({paths['get_gpu_addr']})
-
 runtime_dir="${{XDG_RUNTIME_DIR:-/run/user/$(id -u)}}"
 display_file="{paths['wayland_display_file']}"
 before_file="$(mktemp)"
@@ -2997,6 +2995,7 @@ logname_value="${{LOGNAME:-$user_value}}"
 shell_value="${{SHELL:-/bin/sh}}"
 dbus_value="${{DBUS_SESSION_BUS_ADDRESS:-unix:path=$runtime_dir/bus}}"
 
+gpu_addr=$({paths['get_gpu_addr']})
 if [ -z "$gpu_addr" ]; then
     // TODO: Create script for internal GPU if no dedicated CPU was found
 else
@@ -3604,8 +3603,13 @@ run_headless_command() {{
     local command_to_run="$1"
     log_debug "running prep command: $command_to_run"
     
-    wlr_drm_devices_value="/dev/dri/by-path/card1"
-    wlr_render_drm_device_value="/dev/dri/renderD128"
+    gpu_addr=$({paths['get_gpu_addr']})
+    if [ -z "$gpu_addr" ]; then
+        // TODO: Create script for internal GPU if no dedicated CPU was found
+    else
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+    fi
     
     local -a launch_command
     launch_command=(/usr/bin/env -i
@@ -3948,8 +3952,13 @@ launch_headless_direct() {{
 {mangohud_fps_limit_block.rstrip()}
     log_debug "launch command: $command_to_run"
 
-    wlr_drm_devices_value="/dev/dri/by-path/card1"
-    wlr_render_drm_device_value="/dev/dri/renderD128"
+    gpu_addr=$({paths['get_gpu_addr']})
+    if [ -z "$gpu_addr" ]; then
+        // TODO: Create script for internal GPU if no dedicated CPU was found
+    else
+        wlr_drm_devices_value="/dev/dri/by-path/pci-$gpu_addr-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-$gpu_addr-render"
+    fi
 
     local -a launch_command
     launch_command=(/usr/bin/env -i

--- a/display/manager.py
+++ b/display/manager.py
@@ -2998,14 +2998,15 @@ dbus_value="${{DBUS_SESSION_BUS_ADDRESS:-unix:path=$runtime_dir/bus}}"
 gpu_addr=$({paths['get_gpu_addr']})
 IFS='-' read -a gpu_array <<< "$gpu_addr"
 
-if [[ -n ${{gpu_array[0]}} ]]; then
-    external_gpu=${{gpu_array[0]}}
-    wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
-    wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
-else
-    internal_gpu=${{gpu_array[1]}}
-    wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
-    wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
+wlr_drm_devices_value=""
+wlr_render_drm_device_value=""
+
+if [[ -n ${{gpu_array[0]:-}} ]]; then
+    wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-card"
+    wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-render"
+elif [[ -n ${{gpu_array[1]:-}} ]]; then
+    wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-card"
+    wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-render"
 fi
 
 cleanup() {{
@@ -3027,24 +3028,31 @@ unset KDE_FULL_SESSION
 unset KDE_SESSION_UID
 unset KDE_SESSION_VERSION
 
-/usr/bin/env -i \
-    HOME="$home_value" \
-    USER="$user_value" \
-    LOGNAME="$logname_value" \
-    SHELL="$shell_value" \
-    PATH="$path_value" \
-    LANG="$lang_value" \
-    XDG_RUNTIME_DIR="$runtime_dir" \
-    DBUS_SESSION_BUS_ADDRESS="$dbus_value" \
-    XDG_SESSION_TYPE=wayland \
-    XDG_CURRENT_DESKTOP=sway \
-    XDG_SESSION_DESKTOP=sway \
-    SWAYSOCK="{state['sway_socket']}" \
-    WLR_BACKENDS=headless,libinput \
-    LIBSEAT_BACKEND=noop \
-    WLR_DRM_DEVICES="$wlr_drm_devices_value" \
-    WLR_RENDER_DRM_DEVICE="$wlr_render_drm_device_value" \
-    /usr/bin/sway --config "{paths['sway_config']}" &
+    local -a sway_cmd=(
+        /usr/bin/env -i
+        "HOME=$home_value"
+        "USER=$user_value"
+        "LOGNAME=$logname_value"
+        "SHELL=$shell_value"
+        "PATH=$path_value"
+        "LANG=$lang_value"
+        "XDG_RUNTIME_DIR=$runtime_dir"
+        "DBUS_SESSION_BUS_ADDRESS=$dbus_value"
+        "XDG_SESSION_TYPE=wayland"
+        "XDG_CURRENT_DESKTOP=sway"
+        "XDG_SESSION_DESKTOP=sway"
+        "SWAYSOCK={state['sway_socket']}"
+        "WLR_BACKENDS=headless,libinput"
+        "LIBSEAT_BACKEND=noop"
+    )
+    if [[ -n $wlr_drm_devices_value ]]; then
+        sway_cmd+=(
+            "WLR_DRM_DEVICES=$wlr_drm_devices_value"
+            "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
+        )
+    fi
+    sway_cmd+=(/usr/bin/sway --config "{paths['sway_config']}")
+    "${{sway_cmd[@]}}" &
 sway_pid=$!
 
 for _ in $(seq 1 100); do
@@ -3611,16 +3619,17 @@ run_headless_command() {{
     gpu_addr=$({paths['get_gpu_addr']})
     IFS='-' read -a gpu_array <<< "$gpu_addr"
 
-    if [[ -n ${{gpu_array[0]}} ]]; then
-        external_gpu=${{gpu_array[0]}}
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
-    else
-        internal_gpu=${{gpu_array[1]}}
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
+    wlr_drm_devices_value=""
+    wlr_render_drm_device_value=""
+
+    if [[ -n ${{gpu_array[0]:-}} ]]; then
+        wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-render"
+    elif [[ -n ${{gpu_array[1]:-}} ]]; then
+        wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-render"
     fi
-    
+
     local -a launch_command
     launch_command=(/usr/bin/env -i
         "HOME=$home_value"
@@ -3642,9 +3651,13 @@ run_headless_command() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
-        "WLR_DRM_DEVICES=$wlr_drm_devices_value"
-        "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
     )
+    if [[ -n $wlr_drm_devices_value ]]; then
+        launch_command+=(
+            "WLR_DRM_DEVICES=$wlr_drm_devices_value"
+            "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
+        )
+    fi
     launch_command+=(/bin/sh -lc "$command_to_run")
     "${{launch_command[@]}}" >>"$launch_log_file" 2>&1
 }}
@@ -3965,14 +3978,15 @@ launch_headless_direct() {{
     gpu_addr=$({paths['get_gpu_addr']})
     IFS='-' read -a gpu_array <<< "$gpu_addr"
 
-    if [[ -n ${{gpu_array[0]}} ]]; then
-        external_gpu=${{gpu_array[0]}}
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$external_gpu-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$external_gpu-render"
-    else
-        internal_gpu=${{gpu_array[1]}}
-        wlr_drm_devices_value="/dev/dri/by-path/pci-$internal_gpu-card"
-        wlr_render_drm_device_value="/dev/dri/by-path/pci-$internal_gpu-render"
+    wlr_drm_devices_value=""
+    wlr_render_drm_device_value=""
+
+    if [[ -n ${{gpu_array[0]:-}} ]]; then
+        wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[0]}}-render"
+    elif [[ -n ${{gpu_array[1]:-}} ]]; then
+        wlr_drm_devices_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-card"
+        wlr_render_drm_device_value="/dev/dri/by-path/pci-${{gpu_array[1]}}-render"
     fi
 
     local -a launch_command
@@ -3997,9 +4011,13 @@ launch_headless_direct() {{
         "PULSE_SINK={audio_sink}"
         "PULSE_SERVER=$pulse_server_value"
         "PULSE_CLIENTCONFIG=$pulse_clientconfig_value"
-        "WLR_DRM_DEVICES=$wlr_drm_devices_value"
-        "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
     )
+    if [[ -n $wlr_drm_devices_value ]]; then
+        launch_command+=(
+            "WLR_DRM_DEVICES=$wlr_drm_devices_value"
+            "WLR_RENDER_DRM_DEVICE=$wlr_render_drm_device_value"
+        )
+    fi
 {mangohud_env_append_block.rstrip()}
     launch_command+=(/bin/sh -lc "$command_to_run")
     setsid "${{launch_command[@]}}" >>"$launch_log_file" 2>&1 &
@@ -4856,6 +4874,7 @@ def _managed_setup_paths(state: Dict[str, Any]) -> List[Path]:
         "reset_resolution_script",
         "input_bridge_script",
         "kwin_input_isolation_script",
+        "get_gpu_addr",
     ]
     return [Path(paths[key]) for key in keys if _safe_string(paths.get(key))]
 


### PR DESCRIPTION
This PR provides the capability to use the discrete GPU on a Multi-GPU System. That shall ensure best encoding and capabilities and performance for streaming.

To be able to use the dedicated GPU two environment variables must be set for wlroots. These are `WLR_RENDER_DRM_DEVICE` and `WLR_DRM_DEVICES`

The documentation of said variables can be found at their [Repo](https://gitlab.freedesktop.org/wlroots/wlroots/-/blob/master/docs/env_vars.md?ref_type=heads)

This connects to #20 